### PR TITLE
feat: persist edited data locally

### DIFF
--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -8,6 +8,8 @@
 
 	// TODO: make the fields more fine grained and then construct the proposal according to a template behind the scenes
 
+	// TODO: refactor the code below to make data saving more generic
+
 	let title = '';
 	let summary = '';
 	let nodeProviderId = '';

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -1,9 +1,52 @@
 <script lang="ts">
 	import Input from '$lib/components/ui/Input.svelte';
+	import { setMetadata } from '$lib/services/idb.services';
+	import { debounce } from '@dfinity/utils';
+	import type { ProposalEditableMetadata } from '$lib/types/juno';
+
+	export let metadata: ProposalEditableMetadata | undefined;
 
 	let title = '';
 	let summary = '';
-	let nodeProviderPid = '';
+	let nodeProviderId = '';
+
+	const init = () => {
+		title = metadata?.title ?? '';
+		summary = metadata?.summary ?? '';
+		nodeProviderId = metadata?.nodeProviderId ?? '';
+	};
+
+	$: metadata, init();
+
+	const save = async () => {
+		if (nodeProviderId === '' && title === '' && summary === '') {
+			return;
+		}
+
+		if (nodeProviderId === metadata?.nodeProviderId && title === metadata?.title && summary === metadata?.summary) {
+			return;
+		}
+
+		await setMetadata({
+			...(title !== '' && { title }),
+			...(summary !== '' && { summary }),
+			...(nodeProviderId !== '' && { nodeProviderId })
+		});
+	};
+
+	const debounceSave = debounce(save);
+
+	$: nodeProviderId,
+		title,
+		summary,
+		(() => {
+			if (nodeProviderId === '' && title === '' && summary === '') {
+				return;
+			}
+
+			debounceSave();
+		})();
+
 </script>
 
 <h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
@@ -24,6 +67,6 @@
 
 <Input
 	placeholder="Node Provider Principal ID"
-	bind:value={nodeProviderPid}
-	pinPlaceholder={nodeProviderPid !== ''}
+	bind:value={nodeProviderId}
+	pinPlaceholder={nodeProviderId !== ''}
 />

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -23,7 +23,11 @@
 			return;
 		}
 
-		if (nodeProviderId === metadata?.nodeProviderId && title === metadata?.title && summary === metadata?.summary) {
+		if (
+			nodeProviderId === metadata?.nodeProviderId &&
+			title === metadata?.title &&
+			summary === metadata?.summary
+		) {
 			return;
 		}
 
@@ -46,7 +50,6 @@
 
 			debounceSave();
 		})();
-
 </script>
 
 <h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -6,6 +6,8 @@
 
 	export let metadata: ProposalEditableMetadata | undefined;
 
+	// TODO: make the fields more fine grained and then construct the proposal according to a template behind the scenes
+
 	let title = '';
 	let summary = '';
 	let nodeProviderId = '';

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if proposalAction === 'AddOrRemoveNodeProvider'}
-	<SubmitAddNodeProvider {metadata}/>
+	<SubmitAddNodeProvider {metadata} />
 {:else}
 	<SubmitMotion {metadata} {content} />
 {/if}

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if proposalAction === 'AddOrRemoveNodeProvider'}
-	<SubmitAddNodeProvider />
+	<SubmitAddNodeProvider {metadata}/>
 {:else}
 	<SubmitMotion {metadata} {content} />
 {/if}

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -88,8 +88,8 @@ export const initUserProposal = async ({
 		}
 
 		const { data, ...metadata } = docMetadata;
-		const { title, url, motionText } = data;
-		const editableMetadata = { title, url, motionText };
+		const { title, url, motionText, summary, nodeProviderId } = data;
+		const editableMetadata = { title, url, motionText, summary, nodeProviderId };
 
 		const { data: jsonContent, ...content } = docContent;
 

--- a/src/lib/types/juno.ts
+++ b/src/lib/types/juno.ts
@@ -9,6 +9,8 @@ export interface ProposalEditableMetadata {
 	title?: string;
 	url?: string;
 	motionText?: string;
+	summary?: string;
+	nodeProviderId?: string;
 }
 
 export type ProposalMetadata = {


### PR DESCRIPTION
### Description
If merged, this PR will allow a user to save the progress of their node provider proposal and visit it later.

### Changes made
Extended `ProposalEditableMetadata` to include extra metadata fields required for node provider proposals

### Testing
Verified correct behavior locally via the UI

### Additional comments
UX needs to be updated so that when "view" is clicked from the "Your Proposals" section, user should be directed to the correct writing step. Currently it redirects to always the second step of the proposal submitting steps.
