### PR TITLE
feat: preselect proposal action when navigating from user proposals

### DIFF
--- a/src/lib/components/proposals/ProposalSelector.svelte
+++ b/src/lib/components/proposals/ProposalSelector.svelte
@@ -1,8 +1,44 @@
 <script lang="ts">
 	import InputSelect from '$lib/components/ui/InputSelect.svelte';
 	import type { ProposalAction } from '$lib/types/governance';
+  import { setMetadata } from '$lib/services/idb.services';
+	import { debounce } from '@dfinity/utils';
+	import type { ProposalEditableMetadata } from '$lib/types/juno';
 
+	export let metadata: ProposalEditableMetadata | undefined;
 	export let proposalAction: ProposalAction | undefined;
+  let isProposalActionSet = false;
+
+	const init = () => {
+		proposalAction = metadata?.proposalAction ?? undefined;
+	};
+
+	$: metadata, init();
+
+	const save = async () => {
+		if (proposalAction === undefined) {
+			return;
+		}
+
+		if (proposalAction === metadata?.proposalAction) {
+			return;
+		}
+
+		await setMetadata({
+			...(proposalAction !== undefined && { proposalAction }),
+		});
+	};
+
+	const debounceSave = debounce(save);
+
+	$:	proposalAction,
+		(() => {
+			if (proposalAction === undefined) {
+				return;
+			}
+      isProposalActionSet = true;
+			debounceSave();
+		})();
 
 	const proposalOptions = [
 		{ value: undefined, label: 'Select an option...' },
@@ -11,7 +47,7 @@
 	];
 </script>
 
-<InputSelect bind:value={proposalAction}>
+<InputSelect bind:value={proposalAction} disabled={isProposalActionSet}>
 	{#each proposalOptions as option (option.value)}
 		<option disabled={option.value === undefined} value={option.value}>{option.label}</option>
 	{/each}

--- a/src/lib/components/proposals/ProposalSelector.svelte
+++ b/src/lib/components/proposals/ProposalSelector.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import InputSelect from '$lib/components/ui/InputSelect.svelte';
 	import type { ProposalAction } from '$lib/types/governance';
-  import { setMetadata } from '$lib/services/idb.services';
+	import { setMetadata } from '$lib/services/idb.services';
 	import { debounce } from '@dfinity/utils';
 	import type { ProposalEditableMetadata } from '$lib/types/juno';
 
 	export let metadata: ProposalEditableMetadata | undefined;
 	export let proposalAction: ProposalAction | undefined;
-  let isProposalActionSet = false;
+	let isProposalActionSet = false;
 
 	const init = () => {
 		proposalAction = metadata?.proposalAction ?? undefined;
@@ -25,18 +25,18 @@
 		}
 
 		await setMetadata({
-			...(proposalAction !== undefined && { proposalAction }),
+			...(proposalAction !== undefined && { proposalAction })
 		});
 	};
 
 	const debounceSave = debounce(save);
 
-	$:	proposalAction,
+	$: proposalAction,
 		(() => {
 			if (proposalAction === undefined) {
 				return;
 			}
-      isProposalActionSet = true;
+			isProposalActionSet = true;
 			debounceSave();
 		})();
 

--- a/src/lib/components/submit/SubmitSelect.svelte
+++ b/src/lib/components/submit/SubmitSelect.svelte
@@ -9,7 +9,7 @@
 
 	let metadata: ProposalEditableMetadata | undefined;
 	export let proposalAction: ProposalAction | undefined;
-	
+
 	const dispatch = createEventDispatcher();
 	const next = () => dispatch('pnwrkNext');
 

--- a/src/lib/components/submit/SubmitSelect.svelte
+++ b/src/lib/components/submit/SubmitSelect.svelte
@@ -2,19 +2,24 @@
 	import ExternalLink from '$lib/components/ui/ExternalLink.svelte';
 	import ProposalSelector from '$lib/components/proposals/ProposalSelector.svelte';
 	import SubmitSelectContinue from '$lib/components/submit/SubmitSelectContinue.svelte';
-	import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher, onMount } from 'svelte';
 	import type { ProposalAction } from '$lib/types/governance';
+	import { getEditable } from '$lib/services/idb.services';
+	import type { ProposalEditableMetadata } from '$lib/types/juno';
 
+	let metadata: ProposalEditableMetadata | undefined;
 	export let proposalAction: ProposalAction | undefined;
-
+	
 	const dispatch = createEventDispatcher();
 	const next = () => dispatch('pnwrkNext');
+
+	onMount(async () => ([metadata] = await getEditable()));
 </script>
 
 <h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">Select Proposal Action</h1>
 
 <div class="flex flex-row mb-4 gap-x-4">
-	<ProposalSelector bind:proposalAction />
+	<ProposalSelector {metadata} bind:proposalAction />
 	<SubmitSelectContinue on:click={next} {proposalAction} />
 </div>
 

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -88,8 +88,8 @@ export const initUserProposal = async ({
 		}
 
 		const { data, ...metadata } = docMetadata;
-		const { title, url, motionText, summary, nodeProviderId } = data;
-		const editableMetadata = { title, url, motionText, summary, nodeProviderId };
+		const { title, url, motionText, summary, nodeProviderId, proposalAction } = data;
+		const editableMetadata = { title, url, motionText, summary, nodeProviderId, proposalAction };
 
 		const { data: jsonContent, ...content } = docContent;
 

--- a/src/lib/types/governance.ts
+++ b/src/lib/types/governance.ts
@@ -51,4 +51,4 @@ export type Proposal = Pick<
 	};
 
 // These types correspond with IC Proposal Documentation (https://wiki.internetcomputer.org/wiki/Network_Nervous_System#Proposals)
-export type ProposalAction = 'Motion' | 'AddOrRemoveNodeProvider';
+export type ProposalAction = 'Motion' | 'AddOrRemoveNodeProvider' | undefined;

--- a/src/lib/types/juno.ts
+++ b/src/lib/types/juno.ts
@@ -1,4 +1,5 @@
 import type { GovernanceCanisterId, Markdown } from '$lib/types/core';
+import type { ProposalAction } from '$lib/types/governance';
 import type { Doc } from '@junobuild/core-peer';
 
 export type ProposalContent = Markdown;
@@ -11,6 +12,7 @@ export interface ProposalEditableMetadata {
 	motionText?: string;
 	summary?: string;
 	nodeProviderId?: string;
+	proposalAction?: ProposalAction;
 }
 
 export type ProposalMetadata = {


### PR DESCRIPTION
### Description
If merged, this PR will "remember" the proposal action selected by the user such that when a user navigates to a saved proposal, the proposal action will be pre-selected and the drop-down will be disabled. See video.

### Changes made
I used the same mechanism for persisting the ProposalEditableMetaData so that the proposal action would always be remembered per proposal. 

### Testing
Verifying the behavior in the UI.
