### PR TITLE
feat: add review step for node provider registration

### DIFF
--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -2,20 +2,19 @@
 	import type { ProposalContent } from '$lib/types/juno';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import { nonNullish } from '@dfinity/utils';
-	import { fade } from 'svelte/transition';
 	import SubmitError from '$lib/components/submit/SubmitError.svelte';
 	import Copy from '$lib/components/ui/Copy.svelte';
 	import { isBusy } from '$lib/derived/busy.derived';
 	import Button from '$lib/components/ui/Button.svelte';
 	import type { ProposalEditableMetadata } from '$lib/types/juno';
 	import { getEditable } from '$lib/services/idb.services';
-	import Container from '$lib/components/ui/Container.svelte';
 	import { submitProposal } from '$lib/services/submit.services';
 	import { userStore } from '$lib/stores/user.store';
-	import HtmlMarkdown from '$lib/components/ui/HtmlMarkdown.svelte';
 	import { governanceStore } from '$lib/derived/governance.derived';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 	import { getContext } from 'svelte';
+	import SubmitReviewAddNodeProvider from '$lib/components/submit/SubmitReviewAddNodeProvider.svelte';
+	import SubmitReviewMotion from '$lib/components/submit/SubmitReviewMotion.svelte';
 
 	export let neuronId: string | undefined;
 
@@ -48,64 +47,26 @@
 </script>
 
 {#if nonNullish(neuronId) && nonNullish(content)}
+	<h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
+		Make sure everything looks good before submitting!
+	</h1>
+
+	<p class="mb-8 leading-relaxed">
+		Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
+	</p>
+
 	{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
-		<div in:fade>
-			<Container>
-				<aside slot="title">Provider's Name</aside>
-				<article class="p-2.5">{$store?.metadata?.title ?? ''}</article>
-			</Container>
-
-			<Container>
-				<aside slot="title">Summary</aside>
-				<article class="p-2.5">{$store?.metadata?.summary ?? ''}</article>
-			</Container>
-
-			<Container>
-				<aside slot="title">The principal ID of the provider</aside>
-				<article class="p-2.5">{$store?.metadata?.nodeProviderId ?? ''}</article>
-			</Container>
-		</div>
-
-		<div class="flex gap-2">
-				<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
-				<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
-		</div>
+		<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
 	{:else}
 		<form on:submit|preventDefault={onSubmit}>
-			<h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
-				Make sure everything looks good before submitting!
-			</h1>
-
-			<p class="mb-8 leading-relaxed">
-				Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
-			</p>
-
-			<div in:fade>
-				<Container>
-					<aside slot="title">The proposal title</aside>
-					<article class="p-2.5">{$store?.metadata?.title ?? ''}</article>
-				</Container>
-
-				<HtmlMarkdown {content} />
-
-				<Container>
-					<aside slot="title">An URL pointing to the forum</aside>
-					<article class="p-2.5">{$store?.metadata?.url ?? ''}</article>
-				</Container>
-
-				<Container>
-					<aside slot="title">Your motion text</aside>
-					<article class="p-2.5">{$store?.metadata?.motionText ?? ''}</article>
-				</Container>
-			</div>
-
-			<div class="flex gap-2">
-				<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
-				<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
-			</div>
+			<SubmitReviewMotion metadata={$store?.metadata} {content} />
 		</form>
 	{/if}
 
+	<div class="flex gap-2">
+		<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
+		<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
+	</div>
 {:else}
 	<SubmitError />
 {/if}

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -14,8 +14,12 @@
 	import { userStore } from '$lib/stores/user.store';
 	import HtmlMarkdown from '$lib/components/ui/HtmlMarkdown.svelte';
 	import { governanceStore } from '$lib/derived/governance.derived';
+	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
+	import { getContext } from 'svelte';
 
 	export let neuronId: string | undefined;
+
+	const { store }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
 	let metadata: ProposalEditableMetadata | undefined;
 	let content: ProposalContent | undefined;
@@ -44,39 +48,64 @@
 </script>
 
 {#if nonNullish(neuronId) && nonNullish(content)}
-	<form on:submit|preventDefault={onSubmit}>
-		<h1 class="font-bold capitalize text-4xl md:text-6xl mb-12">
-			Make sure everything looks good before submitting!
-		</h1>
-
-		<p class="leading-relaxed mb-8">
-			Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
-		</p>
-
+	{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
 		<div in:fade>
 			<Container>
-				<aside slot="title">The proposal title</aside>
-				<article class="p-2.5">{metadata?.title ?? ''}</article>
-			</Container>
-
-			<HtmlMarkdown {content} />
-
-			<Container>
-				<aside slot="title">An URL pointing to the forum</aside>
-				<article class="p-2.5">{metadata?.url ?? ''}</article>
+				<aside slot="title">Provider's Name</aside>
+				<article class="p-2.5">{$store?.metadata?.title ?? ''}</article>
 			</Container>
 
 			<Container>
-				<aside slot="title">Your motion text</aside>
-				<article class="p-2.5">{metadata?.motionText ?? ''}</article>
+				<aside slot="title">Summary</aside>
+				<article class="p-2.5">{$store?.metadata?.summary ?? ''}</article>
+			</Container>
+
+			<Container>
+				<aside slot="title">The principal ID of the provider</aside>
+				<article class="p-2.5">{$store?.metadata?.nodeProviderId ?? ''}</article>
 			</Container>
 		</div>
 
 		<div class="flex gap-2">
-			<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
-			<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
+				<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
+				<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
 		</div>
-	</form>
+	{:else}
+		<form on:submit|preventDefault={onSubmit}>
+			<h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
+				Make sure everything looks good before submitting!
+			</h1>
+
+			<p class="mb-8 leading-relaxed">
+				Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
+			</p>
+
+			<div in:fade>
+				<Container>
+					<aside slot="title">The proposal title</aside>
+					<article class="p-2.5">{$store?.metadata?.title ?? ''}</article>
+				</Container>
+
+				<HtmlMarkdown {content} />
+
+				<Container>
+					<aside slot="title">An URL pointing to the forum</aside>
+					<article class="p-2.5">{$store?.metadata?.url ?? ''}</article>
+				</Container>
+
+				<Container>
+					<aside slot="title">Your motion text</aside>
+					<article class="p-2.5">{$store?.metadata?.motionText ?? ''}</article>
+				</Container>
+			</div>
+
+			<div class="flex gap-2">
+				<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
+				<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>
+			</div>
+		</form>
+	{/if}
+
 {:else}
 	<SubmitError />
 {/if}

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -15,6 +15,7 @@
 	import { getContext } from 'svelte';
 	import SubmitReviewAddNodeProvider from '$lib/components/submit/SubmitReviewAddNodeProvider.svelte';
 	import SubmitReviewMotion from '$lib/components/submit/SubmitReviewMotion.svelte';
+	import { fade } from 'svelte/transition';
 
 	export let neuronId: string | undefined;
 
@@ -56,6 +57,7 @@
 	</p>
 
 	<!-- TODO: Use the context directly within the component instead of passing the metadata -->
+	<div transition:fade>
 	{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
 		<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
 	{:else}
@@ -63,7 +65,8 @@
 			<SubmitReviewMotion {metadata} {content} />
 		</form>
 	{/if}
-
+	</div>
+	
 	<div class="flex gap-2">
 		<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
 		<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -58,15 +58,15 @@
 
 	<!-- TODO: Use the context directly within the component instead of passing the metadata -->
 	<div transition:fade>
-	{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
-		<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
-	{:else}
-		<form on:submit|preventDefault={onSubmit}>
-			<SubmitReviewMotion {metadata} {content} />
-		</form>
-	{/if}
+		{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
+			<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
+		{:else}
+			<form on:submit|preventDefault={onSubmit}>
+				<SubmitReviewMotion {metadata} {content} />
+			</form>
+		{/if}
 	</div>
-	
+
 	<div class="flex gap-2">
 		<Button color="quaternary" type="button" disabled={$isBusy} on:click={edit}>Edit</Button>
 		<Button color="tertiary" type="submit" disabled={$isBusy}>Submit</Button>

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -59,7 +59,7 @@
 		<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
 	{:else}
 		<form on:submit|preventDefault={onSubmit}>
-			<SubmitReviewMotion metadata={$store?.metadata} {content} />
+			<SubmitReviewMotion {metadata} {content} />
 		</form>
 	{/if}
 

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -55,6 +55,7 @@
 		Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
 	</p>
 
+	<!-- TODO: Use the context directly within the component instead of passing the metadata -->
 	{#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
 		<SubmitReviewAddNodeProvider metadata={$store?.metadata} />
 	{:else}

--- a/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
@@ -1,0 +1,25 @@
+<!-- ProviderDetails.svelte -->
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import Container from '$lib/components/ui/Container.svelte';
+	import type { ProposalEditableMetadata } from '$lib/types/juno';
+
+	export let metadata: ProposalEditableMetadata | undefined;
+</script>
+
+<div in:fade>
+	<Container>
+		<aside slot="title">Provider's Name</aside>
+		<article class="p-2.5">{metadata?.title ?? ''}</article>
+	</Container>
+
+	<Container>
+		<aside slot="title">Summary</aside>
+		<article class="p-2.5">{metadata?.summary ?? ''}</article>
+	</Container>
+
+	<Container>
+		<aside slot="title">The principal ID of the provider</aside>
+		<article class="p-2.5">{metadata?.nodeProviderId ?? ''}</article>
+	</Container>
+</div>

--- a/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
@@ -1,4 +1,3 @@
-<!-- ProviderDetails.svelte -->
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import Container from '$lib/components/ui/Container.svelte';

--- a/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
@@ -1,24 +1,22 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
 	import Container from '$lib/components/ui/Container.svelte';
 	import type { ProposalEditableMetadata } from '$lib/types/juno';
 
 	export let metadata: ProposalEditableMetadata | undefined;
 </script>
 
-<div in:fade>
-	<Container>
-		<aside slot="title">Provider's Name</aside>
-		<article class="p-2.5">{metadata?.title ?? ''}</article>
-	</Container>
+<Container>
+	<aside slot="title">Provider's Name</aside>
+	<article class="p-2.5">{metadata?.title ?? ''}</article>
+</Container>
 
-	<Container>
-		<aside slot="title">Summary</aside>
-		<article class="p-2.5">{metadata?.summary ?? ''}</article>
-	</Container>
+<Container>
+	<aside slot="title">Summary</aside>
+	<article class="p-2.5">{metadata?.summary ?? ''}</article>
+</Container>
 
-	<Container>
-		<aside slot="title">The principal ID of the provider</aside>
-		<article class="p-2.5">{metadata?.nodeProviderId ?? ''}</article>
-	</Container>
-</div>
+<Container>
+	<aside slot="title">The principal ID of the provider</aside>
+	<article class="p-2.5">{metadata?.nodeProviderId ?? ''}</article>
+</Container>
+

--- a/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitReviewAddNodeProvider.svelte
@@ -19,4 +19,3 @@
 	<aside slot="title">The principal ID of the provider</aside>
 	<article class="p-2.5">{metadata?.nodeProviderId ?? ''}</article>
 </Container>
-

--- a/src/lib/components/submit/SubmitReviewMotion.svelte
+++ b/src/lib/components/submit/SubmitReviewMotion.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
 	import Container from '$lib/components/ui/Container.svelte';
 	import HtmlMarkdown from '$lib/components/ui/HtmlMarkdown.svelte';
 	import type { ProposalEditableMetadata } from '$lib/types/juno';
@@ -9,21 +8,20 @@
 	export let content: ProposalContent | undefined;
 </script>
 
-<div in:fade>
-	<Container>
-		<aside slot="title">The proposal title</aside>
-		<article class="p-2.5">{metadata?.title ?? ''}</article>
-	</Container>
+<Container>
+	<aside slot="title">The proposal title</aside>
+	<article class="p-2.5">{metadata?.title ?? ''}</article>
+</Container>
 
-	<HtmlMarkdown {content} />
+<HtmlMarkdown {content} />
 
-	<Container>
-		<aside slot="title">An URL pointing to the forum</aside>
-		<article class="p-2.5">{metadata?.url ?? ''}</article>
-	</Container>
+<Container>
+	<aside slot="title">An URL pointing to the forum</aside>
+	<article class="p-2.5">{metadata?.url ?? ''}</article>
+</Container>
 
-	<Container>
-		<aside slot="title">Your motion text</aside>
-		<article class="p-2.5">{metadata?.motionText ?? ''}</article>
-	</Container>
-</div>
+<Container>
+	<aside slot="title">Your motion text</aside>
+	<article class="p-2.5">{metadata?.motionText ?? ''}</article>
+</Container>
+

--- a/src/lib/components/submit/SubmitReviewMotion.svelte
+++ b/src/lib/components/submit/SubmitReviewMotion.svelte
@@ -1,0 +1,32 @@
+<!-- ProposalDetails.svelte -->
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import Container from '$lib/components/ui/Container.svelte';
+	import HtmlMarkdown from '$lib/components/ui/HtmlMarkdown.svelte';
+	import type { ProposalEditableMetadata } from '$lib/types/juno';
+	import type { ProposalContent } from '$lib/types/juno';
+
+	export let metadata: ProposalEditableMetadata | undefined;
+	export let content: ProposalContent | undefined;
+
+	// You can add any additional logic needed here
+</script>
+
+<div in:fade>
+	<Container>
+		<aside slot="title">The proposal title</aside>
+		<article class="p-2.5">{metadata?.title ?? ''}</article>
+	</Container>
+
+	<HtmlMarkdown {content} />
+
+	<Container>
+		<aside slot="title">An URL pointing to the forum</aside>
+		<article class="p-2.5">{metadata?.url ?? ''}</article>
+	</Container>
+
+	<Container>
+		<aside slot="title">Your motion text</aside>
+		<article class="p-2.5">{metadata?.motionText ?? ''}</article>
+	</Container>
+</div>

--- a/src/lib/components/submit/SubmitReviewMotion.svelte
+++ b/src/lib/components/submit/SubmitReviewMotion.svelte
@@ -1,4 +1,3 @@
-<!-- ProposalDetails.svelte -->
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import Container from '$lib/components/ui/Container.svelte';
@@ -8,8 +7,6 @@
 
 	export let metadata: ProposalEditableMetadata | undefined;
 	export let content: ProposalContent | undefined;
-
-	// You can add any additional logic needed here
 </script>
 
 <div in:fade>

--- a/src/lib/components/submit/SubmitReviewMotion.svelte
+++ b/src/lib/components/submit/SubmitReviewMotion.svelte
@@ -24,4 +24,3 @@
 	<aside slot="title">Your motion text</aside>
 	<article class="p-2.5">{metadata?.motionText ?? ''}</article>
 </Container>
-


### PR DESCRIPTION
### Description
Fixes #20 

### Changes made
- Add check to see if proposal action is adding a node provider, then load corresponding fields.
- Extract the review for motion and add node provider proposals into separate components

### Testing
Only UI testing

### Additional comments
In issue #17 I plan to add more granular fields. This will mean that the fields in the review step for the node provider will also change.