### PR TITLE
feat: submit add node provider proposal

### DIFF
--- a/src/lib/api/icp-proposal.api.ts
+++ b/src/lib/api/icp-proposal.api.ts
@@ -1,6 +1,6 @@
 import { getAgent } from '$lib/api/agent.api';
 import { GOVERNANCE_CANISTER_ID, NETWORK_PAGINATION } from '$lib/constants/app.constants';
-import type { MotionProposalParams } from '$lib/services/proposal.services';
+import type { MotionProposalParams, AddNodeProviderProposalParams } from '$lib/services/proposal.services';
 import { enumsExclude } from '$lib/utils/enum.utils';
 import { AnonymousIdentity } from '@dfinity/agent';
 import type { ListProposalsResponse, ProposalInfo } from '@dfinity/nns';
@@ -71,6 +71,13 @@ export const makeMotionProposal = async (
 	return makeProposal(request);
 };
 
+export const makeAddNodeProviderProposal = async (
+	params: Omit<AddNodeProviderProposalParams, 'governance'>
+): Promise<ProposalId | undefined> => {
+	const request = makeNodeProviderProposalRequest(params);
+	return makeProposal(request);
+};
+
 const makeProposal = async (request: MakeProposalRequest): Promise<ProposalId | undefined> => {
 	assertNonNullish(GOVERNANCE_CANISTER_ID, 'The ICP governance canister ID is not set.');
 
@@ -92,6 +99,26 @@ const makeMotionProposalRequest = ({
 	action: {
 		Motion: {
 			motionText
+		}
+	},
+	neuronId: BigInt(neuronId),
+	...rest
+});
+
+
+const makeNodeProviderProposalRequest = ({
+	id,
+	neuronId,
+	...rest
+}: Omit<AddNodeProviderProposalParams, 'governance'>): MakeProposalRequest => ({
+	action: {
+		AddOrRemoveNodeProvider: {
+			change: {
+				ToAdd: {
+					id: id,
+					rewardAccount: undefined
+				}
+			}
 		}
 	},
 	neuronId: BigInt(neuronId),

--- a/src/lib/api/icp-proposal.api.ts
+++ b/src/lib/api/icp-proposal.api.ts
@@ -1,6 +1,9 @@
 import { getAgent } from '$lib/api/agent.api';
 import { GOVERNANCE_CANISTER_ID, NETWORK_PAGINATION } from '$lib/constants/app.constants';
-import type { MotionProposalParams, AddNodeProviderProposalParams } from '$lib/services/proposal.services';
+import type {
+	AddNodeProviderProposalParams,
+	MotionProposalParams
+} from '$lib/services/proposal.services';
 import { enumsExclude } from '$lib/utils/enum.utils';
 import { AnonymousIdentity } from '@dfinity/agent';
 import type { ListProposalsResponse, ProposalInfo } from '@dfinity/nns';
@@ -104,7 +107,6 @@ const makeMotionProposalRequest = ({
 	neuronId: BigInt(neuronId),
 	...rest
 });
-
 
 const makeNodeProviderProposalRequest = ({
 	id,

--- a/src/lib/api/icp-proposal.api.ts
+++ b/src/lib/api/icp-proposal.api.ts
@@ -108,6 +108,7 @@ const makeMotionProposalRequest = ({
 
 const makeNodeProviderProposalRequest = ({
 	id,
+	rewardAccount,
 	neuronId,
 	...rest
 }: Omit<AddNodeProviderProposalParams, 'governance'>): MakeProposalRequest => ({
@@ -115,8 +116,8 @@ const makeNodeProviderProposalRequest = ({
 		AddOrRemoveNodeProvider: {
 			change: {
 				ToAdd: {
-					id: id,
-					rewardAccount: undefined
+					id,
+					rewardAccount
 				}
 			}
 		}

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -55,7 +55,6 @@
 		await setMetadata({
 			...($store?.metadata ?? {}),
 			...(nodeProviderName !== '' && { nodeProviderName }),
-			...(nodeProviderName !== '' && { nodeProviderName }),
 			...(url !== '' && { url }),
 			...(urlSelfDeclaration !== '' && { urlSelfDeclaration }),
 			...(urlIdentityProof !== '' && { urlIdentityProof }),

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -7,7 +7,7 @@
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
-	let title = ''
+	let title = '';
 	let summary = '';
 	let nodeProviderName = '';
 	let url = '';
@@ -54,8 +54,21 @@
 			return;
 		}
 
-		title = "Add node provider: " + nodeProviderName;
-		summary = "Register a node provider" + nodeProviderName + " in line with the announcement and discussion at " + url + ". The self-declaration documentation is available at " + urlSelfDeclaration + " with SHA256 hash: " + hashSelfDeclaration + ". The proof of identity is available at " + urlIdentityProof + " with SHA256 hash: " + hashIdentityProof + "."
+		title = 'Add Node Provider: ' + nodeProviderName;
+		summary =
+			'Register a node provider' +
+			nodeProviderName +
+			' in line with the announcement and discussion at ' +
+			url +
+			'. The self-declaration documentation is available at ' +
+			urlSelfDeclaration +
+			' with SHA256 hash: ' +
+			hashSelfDeclaration +
+			'. The proof of identity is available at ' +
+			urlIdentityProof +
+			' with SHA256 hash: ' +
+			hashIdentityProof +
+			'.';
 
 		await setMetadata({
 			...($store?.metadata ?? {}),

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -7,8 +7,6 @@
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
-	let title = '';
-	let summary = '';
 	let nodeProviderName = '';
 	let url = '';
 	let urlSelfDeclaration = '';
@@ -54,26 +52,8 @@
 			return;
 		}
 
-		title = 'Add Node Provider: ' + nodeProviderName;
-		summary =
-			'Register a node provider' +
-			nodeProviderName +
-			' in line with the announcement and discussion at ' +
-			url +
-			'. The self-declaration documentation is available at ' +
-			urlSelfDeclaration +
-			' with SHA256 hash: ' +
-			hashSelfDeclaration +
-			'. The proof of identity is available at ' +
-			urlIdentityProof +
-			' with SHA256 hash: ' +
-			hashIdentityProof +
-			'.';
-
 		await setMetadata({
 			...($store?.metadata ?? {}),
-			...(title !== '' && { title }),
-			...(summary !== '' && { summary }),
 			...(nodeProviderName !== '' && { nodeProviderName }),
 			...(nodeProviderName !== '' && { nodeProviderName }),
 			...(url !== '' && { url }),

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -7,6 +7,8 @@
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
+	let title = ''
+	let summary = '';
 	let nodeProviderName = '';
 	let url = '';
 	let urlSelfDeclaration = '';
@@ -52,8 +54,14 @@
 			return;
 		}
 
+		title = "Add node provider: " + nodeProviderName;
+		summary = "Register a node provider" + nodeProviderName + " in line with the announcement and discussion at " + url + ". The self-declaration documentation is available at " + urlSelfDeclaration + " with SHA256 hash: " + hashSelfDeclaration + ". The proof of identity is available at " + urlIdentityProof + " with SHA256 hash: " + hashIdentityProof + "."
+
 		await setMetadata({
 			...($store?.metadata ?? {}),
+			...(title !== '' && { title }),
+			...(summary !== '' && { summary }),
+			...(nodeProviderName !== '' && { nodeProviderName }),
 			...(nodeProviderName !== '' && { nodeProviderName }),
 			...(url !== '' && { url }),
 			...(urlSelfDeclaration !== '' && { urlSelfDeclaration }),

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -33,12 +33,7 @@
 	const dispatch = createEventDispatcher();
 
 	const onSubmit = async () => {
-		let submitProposal;
-		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
-			submitProposal = submitAddNodeProviderProposal;
-		} else {
-			submitProposal = submitMotionProposal;
-		}
+		const submitProposal = $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider' ? submitAddNodeProviderProposal : submitMotionProposal;
 
 		const { result, proposalId } = await submitProposal({
 			user: $userStore,

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -7,7 +7,7 @@
 	import { isBusy } from '$lib/derived/busy.derived';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { getEditable } from '$lib/services/idb.services';
-	import { submitMotionProposal } from '$lib/services/submit.services';
+	import { submitMotionProposal, submitAddNodeProviderProposal } from '$lib/services/submit.services';
 	import { userStore } from '$lib/stores/user.store';
 	import { governanceStore } from '$lib/derived/governance.derived';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
@@ -30,6 +30,22 @@
 	const dispatch = createEventDispatcher();
 
 	const onSubmit = async () => {
+		if($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'){
+			console.log("add np proposal flow");
+			const { result, proposalId } = await submitAddNodeProviderProposal({
+				user: $userStore,
+				neuronId,
+				governance: $governanceStore
+			});
+
+			if (result === 'error') {
+				return;
+			}
+
+			dispatch('pnwrkDone', proposalId);
+
+			return;
+		}
 		const { result, proposalId } = await submitMotionProposal({
 			user: $userStore,
 			neuronId,
@@ -48,11 +64,11 @@
 
 {#if nonNullish(neuronId) && nonNullish(content)}
 	<form on:submit|preventDefault={onSubmit}>
-		<h1 class="font-bold capitalize text-4xl md:text-6xl mb-12">
+		<h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
 			Make sure everything looks good before submitting!
 		</h1>
 
-		<p class="leading-relaxed mb-8">
+		<p class="mb-8 leading-relaxed">
 			Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
 		</p>
 

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -33,7 +33,10 @@
 	const dispatch = createEventDispatcher();
 
 	const onSubmit = async () => {
-		const submitProposal = $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider' ? submitAddNodeProviderProposal : submitMotionProposal;
+		const submitProposal =
+			$store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'
+				? submitAddNodeProviderProposal
+				: submitMotionProposal;
 
 		const { result, proposalId } = await submitProposal({
 			user: $userStore,

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -34,7 +34,6 @@
 
 	const onSubmit = async () => {
 		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
-			console.log('add np proposal flow');
 			const { result, proposalId } = await submitAddNodeProviderProposal({
 				user: $userStore,
 				neuronId,

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -7,7 +7,10 @@
 	import { isBusy } from '$lib/derived/busy.derived';
 	import Button from '$lib/components/ui/Button.svelte';
 	import { getEditable } from '$lib/services/idb.services';
-	import { submitMotionProposal, submitAddNodeProviderProposal } from '$lib/services/submit.services';
+	import {
+		submitMotionProposal,
+		submitAddNodeProviderProposal
+	} from '$lib/services/submit.services';
 	import { userStore } from '$lib/stores/user.store';
 	import { governanceStore } from '$lib/derived/governance.derived';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
@@ -30,8 +33,8 @@
 	const dispatch = createEventDispatcher();
 
 	const onSubmit = async () => {
-		if($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'){
-			console.log("add np proposal flow");
+		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
+			console.log('add np proposal flow');
 			const { result, proposalId } = await submitAddNodeProviderProposal({
 				user: $userStore,
 				neuronId,

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -62,7 +62,7 @@
 			Make sure everything looks good before submitting!
 		</h1>
 
-		<p class="mb-8 leading-relaxed">
+		<p class="leading-relaxed mb-8">
 			Review your proposal for Neuron ID: <Copy value={`${neuronId}`} text="Neuron ID copied." />.
 		</p>
 

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -66,7 +66,7 @@
 
 {#if nonNullish(neuronId) && nonNullish(content)}
 	<form on:submit|preventDefault={onSubmit}>
-		<h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">
+		<h1 class="font-bold capitalize text-4xl md:text-6xl mb-12">
 			Make sure everything looks good before submitting!
 		</h1>
 

--- a/src/lib/components/submit/SubmitReview.svelte
+++ b/src/lib/components/submit/SubmitReview.svelte
@@ -33,22 +33,14 @@
 	const dispatch = createEventDispatcher();
 
 	const onSubmit = async () => {
+		let submitProposal;
 		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
-			const { result, proposalId } = await submitAddNodeProviderProposal({
-				user: $userStore,
-				neuronId,
-				governance: $governanceStore
-			});
-
-			if (result === 'error') {
-				return;
-			}
-
-			dispatch('pnwrkDone', proposalId);
-
-			return;
+			submitProposal = submitAddNodeProviderProposal;
+		} else {
+			submitProposal = submitMotionProposal;
 		}
-		const { result, proposalId } = await submitMotionProposal({
+
+		const { result, proposalId } = await submitProposal({
 			user: $userStore,
 			neuronId,
 			governance: $governanceStore

--- a/src/lib/services/proposal.services.ts
+++ b/src/lib/services/proposal.services.ts
@@ -52,7 +52,7 @@ export const submitAddNodeProviderProposal = async ({
 	result: 'ok' | 'error';
 	proposalId: bigint | undefined;
 }> => {
-	const submit = async (): Promise<bigint | undefined> => {
+	const submit = (): Promise<bigint | undefined> => {
 		return makeAddNodeProviderProposal(rest);
 	};
 

--- a/src/lib/services/proposal.services.ts
+++ b/src/lib/services/proposal.services.ts
@@ -1,7 +1,7 @@
 import {
 	getProposal as getProposalNns,
-	makeMotionProposal as makeMotionProposalICP,
-	makeAddNodeProviderProposal
+	makeAddNodeProviderProposal,
+	makeMotionProposal as makeMotionProposalICP
 } from '$lib/api/icp-proposal.api';
 import {
 	getProposal as getProposalSns,
@@ -12,7 +12,7 @@ import { toasts } from '$lib/stores/toasts.store';
 import type { Governance, OptionGovernanceId, Proposal } from '$lib/types/governance';
 import { mapIcpProposal } from '$lib/utils/icp-proposals.utils';
 import { mapSnsProposal } from '$lib/utils/sns-proposals.utils';
-import type { MakeProposalRequest, Motion, ProposalId, AddOrRemoveNodeProvider, Change, NodeProvider } from '@dfinity/nns';
+import type { MakeProposalRequest, Motion, NodeProvider, ProposalId } from '@dfinity/nns';
 import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -52,8 +52,8 @@ export const submitAddNodeProviderProposal = async ({
 	result: 'ok' | 'error';
 	proposalId: bigint | undefined;
 }> => {
-	const submit = async (governance: Governance): Promise<bigint | undefined> => {
-		return  makeAddNodeProviderProposal({ ...rest })
+	const submit = async (): Promise<bigint | undefined> => {
+		return makeAddNodeProviderProposal({ ...rest });
 	};
 
 	return submitProposal({

--- a/src/lib/services/proposal.services.ts
+++ b/src/lib/services/proposal.services.ts
@@ -1,6 +1,7 @@
 import {
 	getProposal as getProposalNns,
-	makeMotionProposal as makeMotionProposalICP
+	makeMotionProposal as makeMotionProposalICP,
+	makeAddNodeProviderProposal
 } from '$lib/api/icp-proposal.api';
 import {
 	getProposal as getProposalSns,
@@ -11,7 +12,7 @@ import { toasts } from '$lib/stores/toasts.store';
 import type { Governance, OptionGovernanceId, Proposal } from '$lib/types/governance';
 import { mapIcpProposal } from '$lib/utils/icp-proposals.utils';
 import { mapSnsProposal } from '$lib/utils/sns-proposals.utils';
-import type { MakeProposalRequest, Motion, ProposalId } from '@dfinity/nns';
+import type { MakeProposalRequest, Motion, ProposalId, AddOrRemoveNodeProvider, Change, NodeProvider } from '@dfinity/nns';
 import { assertNonNullish, nonNullish } from '@dfinity/utils';
 import { get } from 'svelte/store';
 
@@ -22,6 +23,8 @@ export type ProposalParams = Omit<MakeProposalRequest, 'action' | 'title' | 'neu
 };
 
 export type MotionProposalParams = ProposalParams & Motion;
+
+export type AddNodeProviderProposalParams = ProposalParams & NodeProvider;
 
 export const submitMotionProposal = async ({
 	governance,
@@ -34,6 +37,23 @@ export const submitMotionProposal = async ({
 		return governance.type === 'icp'
 			? await makeMotionProposalICP({ ...rest })
 			: await makeMotionProposalSns({ ...rest, governanceId: governance.id });
+	};
+
+	return submitProposal({
+		governance,
+		fn: submit
+	});
+};
+
+export const submitAddNodeProviderProposal = async ({
+	governance,
+	...rest
+}: AddNodeProviderProposalParams): Promise<{
+	result: 'ok' | 'error';
+	proposalId: bigint | undefined;
+}> => {
+	const submit = async (governance: Governance): Promise<bigint | undefined> => {
+		return  makeAddNodeProviderProposal({ ...rest })
 	};
 
 	return submitProposal({

--- a/src/lib/services/proposal.services.ts
+++ b/src/lib/services/proposal.services.ts
@@ -53,7 +53,7 @@ export const submitAddNodeProviderProposal = async ({
 	proposalId: bigint | undefined;
 }> => {
 	const submit = async (): Promise<bigint | undefined> => {
-		return makeAddNodeProviderProposal({ ...rest });
+		return makeAddNodeProviderProposal(rest);
 	};
 
 	return submitProposal({

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -7,8 +7,8 @@ import {
 	init
 } from '$lib/services/idb.services';
 import {
-	submitMotionProposal as submitMotionProposalApi,
 	submitAddNodeProviderProposal as submitAddNodeProviderProposalApi,
+	submitMotionProposal as submitMotionProposalApi,
 	type ProposalParams
 } from '$lib/services/proposal.services';
 import { busy } from '$lib/stores/busy.store';

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -225,7 +225,23 @@ export const submitAddNodeProviderProposal = async ({
 		ProposalParams,
 		'neuronId'
 	>): Promise<SubmitProposalResult> => {
-		const { title, url, nodeProviderId, summary } = metadata;
+		const { url, nodeProviderId } = metadata;
+
+		const title = 'Add Node Provider: ' + metadata?.nodeProviderName;
+		const summary =
+			'Register a node provider' +
+			metadata?.nodeProviderName +
+			' in line with the announcement and discussion at ' +
+			metadata?.url +
+			'. \n\nThe self-declaration documentation is available at ' +
+			metadata?.urlSelfDeclaration +
+			' \nwith SHA256 hash: ' +
+			metadata?.hashSelfDeclaration +
+			'.\n\nThe proof of identity is available at ' +
+			metadata?.urlIdentityProof +
+			' \nwith SHA256 hash: ' +
+			metadata?.hashIdentityProof +
+			'.';
 
 		if (isNullish(title) || isNullish(url) || isNullish(nodeProviderId) || isNullish(summary)) {
 			toasts.error({

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -234,21 +234,8 @@ export const submitAddNodeProviderProposal = async ({
 			return { result: 'error' };
 		}
 
-		const title = 'Add Node Provider: ' + metadata?.nodeProviderName;
-		const summary =
-			'Register a node provider' +
-			metadata?.nodeProviderName +
-			' in line with the announcement and discussion at ' +
-			metadata?.url +
-			'. \n\nThe self-declaration documentation is available at ' +
-			metadata?.urlSelfDeclaration +
-			' \nwith SHA256 hash: ' +
-			metadata?.hashSelfDeclaration +
-			'.\n\nThe proof of identity is available at ' +
-			metadata?.urlIdentityProof +
-			' \nwith SHA256 hash: ' +
-			metadata?.hashIdentityProof +
-			'.';
+		const title = `Add Node Provider: ${metadata?.nodeProviderName}`;
+		const summary = `Register a node provider ${metadata?.nodeProviderName} in line with the announcement and discussion at:\n\n ${metadata?.url}.\n\nThe self-declaration documentation is available at:\n\n${metadata?.urlSelfDeclaration} \n\nwith SHA256 hash:\n\n${metadata?.hashSelfDeclaration}.\n\nThe proof of identity is available at:\n\n${metadata?.urlIdentityProof} \n\nwith SHA256 hash:\n\n${metadata?.hashIdentityProof}.`;
 
 		return submitAddNodeProviderProposalApi({
 			title,

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -227,6 +227,13 @@ export const submitAddNodeProviderProposal = async ({
 	>): Promise<SubmitProposalResult> => {
 		const { url, nodeProviderId } = metadata;
 
+		if (isNullish(url) || isNullish(nodeProviderId)) {
+			toasts.error({
+				msg: { text: 'No url or node provider ID to submit the proposal.' }
+			});
+			return { result: 'error' };
+		}
+
 		const title = 'Add Node Provider: ' + metadata?.nodeProviderName;
 		const summary =
 			'Register a node provider' +
@@ -242,22 +249,6 @@ export const submitAddNodeProviderProposal = async ({
 			' \nwith SHA256 hash: ' +
 			metadata?.hashIdentityProof +
 			'.';
-
-		if (isNullish(title) || isNullish(url) || isNullish(nodeProviderId) || isNullish(summary)) {
-			toasts.error({
-				msg: { text: 'No title, url, node provider ID or summary to submit the proposal.' }
-			});
-			return { result: 'error' };
-		}
-
-		const [_, content] = await getEditable();
-
-		if (isNullish(content)) {
-			toasts.error({
-				msg: { text: 'No content to submit the proposal.' }
-			});
-			return { result: 'error' };
-		}
 
 		return submitAddNodeProviderProposalApi({
 			title,

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -225,13 +225,11 @@ export const submitAddNodeProviderProposal = async ({
 		ProposalParams,
 		'neuronId'
 	>): Promise<SubmitProposalResult> => {
-		const { url, nodeProviderId } = metadata;
-		const summary = "Hard coded summary";
-		const title = "Hard coded title";
+		const { title, url, nodeProviderId, summary } = metadata;
 
-		if (isNullish(title) || isNullish(url) || isNullish(nodeProviderId)) {
+		if (isNullish(title) || isNullish(url) || isNullish(nodeProviderId) || isNullish(summary)) {
 			toasts.error({
-				msg: { text: 'No title, url or node provider ID to submit the proposal.' }
+				msg: { text: 'No title, url, node provider ID or summary to submit the proposal.' }
 			});
 			return { result: 'error' };
 		}

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/services/idb.services';
 import {
 	submitMotionProposal as submitMotionProposalApi,
+	submitAddNodeProviderProposal as submitAddNodeProviderProposalApi,
 	type ProposalParams
 } from '$lib/services/proposal.services';
 import { busy } from '$lib/stores/busy.store';
@@ -198,6 +199,58 @@ export const submitMotionProposal = async ({
 			url,
 			motionText,
 			summary: content,
+			neuronId,
+			governance
+		});
+	};
+
+	return submitProposal({
+		neuronId,
+		fn: submit,
+		...rest
+	});
+};
+
+export const submitAddNodeProviderProposal = async ({
+	neuronId,
+	governance,
+	...rest
+}: {
+	user: UserOption;
+} & Partial<Pick<ProposalParams, 'neuronId' | 'governance'>>): Promise<SubmitProposalResult> => {
+	const submit = async ({
+		metadata,
+		neuronId
+	}: { metadata: ProposalEditableMetadata } & Pick<
+		ProposalParams,
+		'neuronId'
+	>): Promise<SubmitProposalResult> => {
+		const { url, nodeProviderId } = metadata;
+		const summary = "Hard coded summary";
+		const title = "Hard coded title";
+
+		if (isNullish(title) || isNullish(url) || isNullish(nodeProviderId)) {
+			toasts.error({
+				msg: { text: 'No title, url or node provider ID to submit the proposal.' }
+			});
+			return { result: 'error' };
+		}
+
+		const [_, content] = await getEditable();
+
+		if (isNullish(content)) {
+			toasts.error({
+				msg: { text: 'No content to submit the proposal.' }
+			});
+			return { result: 'error' };
+		}
+
+		return submitAddNodeProviderProposalApi({
+			title,
+			url,
+			id: nodeProviderId,
+			rewardAccount: undefined,
+			summary,
 			neuronId,
 			governance
 		});


### PR DESCRIPTION
### Description
If this PR is accepted, it will effectively submit the add node provider proposal and it will be visible on NNS dApp.

### Changes made
- Extended the current submit proposal pipeline to have a `SubmitNodeProviderProposalAction` at each step of the process

### Additional comments
I think a separate PR is needed to refactor `SubmitAddNodeProvider.svelte` so that the rest of the metadata fields can be aggregated into a single "content" variable. Or maybe there is a better approach? Let me know what you think!

Thanks for reviewing this PR!