### PR TITLE
feat: add node provider proposal input validation

### DIFF
--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -6,7 +6,6 @@
 	import { getContext } from 'svelte';
 	import { toasts } from '$lib/stores/toasts.store';
 
-
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
 	let nodeProviderName = '';
@@ -115,14 +114,18 @@
 
 		if (!urlSelfDeclaration.startsWith(validUrlDomain)) {
 			toasts.error({
-				msg: { text: 'Invalid URL for self-declaration: make sure the url is from <https://wiki.internetcomputer.org/>' }
+				msg: {
+					text: 'Invalid URL for self-declaration: make sure the url is from <https://wiki.internetcomputer.org/>'
+				}
 			});
 			return false;
 		}
 
 		if (!urlIdentityProof.startsWith(validUrlDomain)) {
 			toasts.error({
-				msg: { text: 'Invalid URL for identity proof: make sure the url is from <https://wiki.internetcomputer.org/>' }
+				msg: {
+					text: 'Invalid URL for identity proof: make sure the url is from <https://wiki.internetcomputer.org/>'
+				}
 			});
 			return false;
 		}

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -4,8 +4,7 @@
 	import { debounce } from '@dfinity/utils';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 	import { getContext } from 'svelte';
-	import { checkFields } from '$lib/services/submit.services';
-	import { toasts } from '$lib/stores/toasts.store';
+	import { fieldsValid } from '$lib/services/submit.services';
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
@@ -94,7 +93,7 @@
 		})();
 
 	export const allFieldsValid = (): boolean => {
-		return checkFields(
+		return fieldsValid(
 			nodeProviderName,
 			url,
 			urlSelfDeclaration,
@@ -103,7 +102,7 @@
 			hashIdentityProof,
 			nodeProviderId
 		);
-	}
+	};
 </script>
 
 <h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -109,12 +109,15 @@
 			return false;
 		}
 
-		if (!urlSelfDeclaration.startsWith(validUrlDomain) || !urlIdentityProof.startsWith(validUrlDomain) ) {
+		if (
+			!urlSelfDeclaration.startsWith(validUrlDomain) ||
+			!urlIdentityProof.startsWith(validUrlDomain)
+		) {
 			console.log('Invalid URL for self-declaration');
 			return false;
 		}
 
-		if (!sha256Regex.test(hashSelfDeclaration) || !sha256Regex.test(hashIdentityProof)){
+		if (!sha256Regex.test(hashSelfDeclaration) || !sha256Regex.test(hashIdentityProof)) {
 			console.log('Invalid SHA256 hash');
 			return false;
 		}

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -4,6 +4,8 @@
 	import { debounce } from '@dfinity/utils';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 	import { getContext } from 'svelte';
+	import { toasts } from '$lib/stores/toasts.store';
+
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
@@ -105,20 +107,37 @@
 		];
 
 		if (fields.some((field) => field === '')) {
-			console.log('fill in all fields');
+			toasts.error({
+				msg: { text: 'Please fill in all fields' }
+			});
 			return false;
 		}
 
-		if (
-			!urlSelfDeclaration.startsWith(validUrlDomain) ||
-			!urlIdentityProof.startsWith(validUrlDomain)
-		) {
-			console.log('Invalid URL for self-declaration');
+		if (!urlSelfDeclaration.startsWith(validUrlDomain)) {
+			toasts.error({
+				msg: { text: 'Invalid URL for self-declaration: make sure the url is from <https://wiki.internetcomputer.org/>' }
+			});
 			return false;
 		}
 
-		if (!sha256Regex.test(hashSelfDeclaration) || !sha256Regex.test(hashIdentityProof)) {
-			console.log('Invalid SHA256 hash');
+		if (!urlIdentityProof.startsWith(validUrlDomain)) {
+			toasts.error({
+				msg: { text: 'Invalid URL for identity proof: make sure the url is from <https://wiki.internetcomputer.org/>' }
+			});
+			return false;
+		}
+
+		if (!sha256Regex.test(hashSelfDeclaration)) {
+			toasts.error({
+				msg: { text: 'Invalid hash for self-declaration: make sure this is a SHA256 hash' }
+			});
+			return false;
+		}
+
+		if (!sha256Regex.test(hashIdentityProof)) {
+			toasts.error({
+				msg: { text: 'Invalid hash for proof of identity: make sure this is a SHA256 hash' }
+			});
 			return false;
 		}
 

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -92,6 +92,7 @@
 		})();
 
 	export function checkFields(): boolean {
+		const validUrlDomain = 'https://wiki.internetcomputer.org/';
 		const fields = [
 			nodeProviderName,
 			url,
@@ -104,6 +105,11 @@
 
 		if (fields.some((field) => field === '')) {
 			console.log('fill in all fields');
+			return false;
+		}
+
+		if (!urlSelfDeclaration.startsWith(validUrlDomain) || !urlIdentityProof.startsWith(validUrlDomain) ) {
+			console.log('Invalid URL for self-declaration');
 			return false;
 		}
 

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -93,6 +93,7 @@
 
 	export function checkFields(): boolean {
 		const validUrlDomain = 'https://wiki.internetcomputer.org/';
+		const sha256Regex = /^[a-fA-F0-9]{64}$/;
 		const fields = [
 			nodeProviderName,
 			url,
@@ -110,6 +111,11 @@
 
 		if (!urlSelfDeclaration.startsWith(validUrlDomain) || !urlIdentityProof.startsWith(validUrlDomain) ) {
 			console.log('Invalid URL for self-declaration');
+			return false;
+		}
+
+		if (!sha256Regex.test(hashSelfDeclaration) || !sha256Regex.test(hashIdentityProof)){
+			console.log('Invalid SHA256 hash');
 			return false;
 		}
 

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -90,6 +90,25 @@
 
 			debounceSave();
 		})();
+
+	export function checkFields(): boolean {
+		const fields = [
+			nodeProviderName,
+			url,
+			urlSelfDeclaration,
+			hashSelfDeclaration,
+			urlIdentityProof,
+			hashIdentityProof,
+			nodeProviderId
+		];
+
+		if (fields.some((field) => field === '')) {
+			console.log('fill in all fields');
+			return false;
+		}
+
+		return true;
+	}
 </script>
 
 <h1 class="mb-12 text-4xl font-bold capitalize md:text-6xl">

--- a/src/lib/components/submit/SubmitAddNodeProvider.svelte
+++ b/src/lib/components/submit/SubmitAddNodeProvider.svelte
@@ -4,6 +4,7 @@
 	import { debounce } from '@dfinity/utils';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 	import { getContext } from 'svelte';
+	import { checkFields } from '$lib/services/submit.services';
 	import { toasts } from '$lib/stores/toasts.store';
 
 	const { store, reload }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
@@ -92,10 +93,8 @@
 			debounceSave();
 		})();
 
-	export function checkFields(): boolean {
-		const validUrlDomain = 'https://wiki.internetcomputer.org/';
-		const sha256Regex = /^[a-fA-F0-9]{64}$/;
-		const fields = [
+	export const allFieldsValid = (): boolean => {
+		return checkFields(
 			nodeProviderName,
 			url,
 			urlSelfDeclaration,
@@ -103,48 +102,7 @@
 			urlIdentityProof,
 			hashIdentityProof,
 			nodeProviderId
-		];
-
-		if (fields.some((field) => field === '')) {
-			toasts.error({
-				msg: { text: 'Please fill in all fields' }
-			});
-			return false;
-		}
-
-		if (!urlSelfDeclaration.startsWith(validUrlDomain)) {
-			toasts.error({
-				msg: {
-					text: 'Invalid URL for self-declaration: make sure the url is from <https://wiki.internetcomputer.org/>'
-				}
-			});
-			return false;
-		}
-
-		if (!urlIdentityProof.startsWith(validUrlDomain)) {
-			toasts.error({
-				msg: {
-					text: 'Invalid URL for identity proof: make sure the url is from <https://wiki.internetcomputer.org/>'
-				}
-			});
-			return false;
-		}
-
-		if (!sha256Regex.test(hashSelfDeclaration)) {
-			toasts.error({
-				msg: { text: 'Invalid hash for self-declaration: make sure this is a SHA256 hash' }
-			});
-			return false;
-		}
-
-		if (!sha256Regex.test(hashIdentityProof)) {
-			toasts.error({
-				msg: { text: 'Invalid hash for proof of identity: make sure this is a SHA256 hash' }
-			});
-			return false;
-		}
-
-		return true;
+		);
 	}
 </script>
 

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -15,16 +15,18 @@
 
 	const dispatch = createEventDispatcher();
 	const next = () => {
-		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
-			if (submitAddNodeProvider.checkFields()) {
-				dispatch('pnwrkNext');
-			} else {
-				console.log('Please fill in all input fields.');
-			}
-		} else {
+		if ($store?.metadata?.proposalAction !== 'AddOrRemoveNodeProvider') {
 			dispatch('pnwrkNext');
+			return;
 		}
+
+		if(!submitAddNodeProvider.checkFields()){
+			return;
+		}
+		
+		dispatch('pnwrkNext');
 	};
+
 </script>
 
 {#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -1,18 +1,34 @@
 <script lang="ts">
 	import SubmitContinue from '$lib/components/submit/SubmitContinue.svelte';
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, SvelteComponent } from 'svelte';
 	import SubmitMotion from '$lib/components/submit/SubmitMotion.svelte';
 	import SubmitAddNodeProvider from '$lib/components/submit/SubmitAddNodeProvider.svelte';
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 
+	interface submitAddNodeProviderComponent extends SvelteComponent<object> {
+		checkFields(): boolean;
+	}
+
+	let submitAddNodeProvider: submitAddNodeProviderComponent;
+
 	const { store }: SubmitContext = getContext<SubmitContext>(SUBMIT_CONTEXT_KEY);
 
 	const dispatch = createEventDispatcher();
-	const next = () => dispatch('pnwrkNext');
+	const next = () => {
+		if ($store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider') {
+			if (submitAddNodeProvider.checkFields()) {
+				dispatch('pnwrkNext');
+			} else {
+				console.log('Please fill in all input fields.');
+			}
+		} else {
+			dispatch('pnwrkNext');
+		}
+	};
 </script>
 
 {#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}
-	<SubmitAddNodeProvider />
+	<SubmitAddNodeProvider bind:this={submitAddNodeProvider} />
 {:else}
 	<SubmitMotion />
 {/if}

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -20,13 +20,12 @@
 			return;
 		}
 
-		if(!submitAddNodeProvider.checkFields()){
+		if (!submitAddNodeProvider.checkFields()) {
 			return;
 		}
-		
+
 		dispatch('pnwrkNext');
 	};
-
 </script>
 
 {#if $store?.metadata?.proposalAction === 'AddOrRemoveNodeProvider'}

--- a/src/lib/components/submit/SubmitWrite.svelte
+++ b/src/lib/components/submit/SubmitWrite.svelte
@@ -6,7 +6,7 @@
 	import { SUBMIT_CONTEXT_KEY, type SubmitContext } from '$lib/types/submit.context';
 
 	interface submitAddNodeProviderComponent extends SvelteComponent<object> {
-		checkFields(): boolean;
+		allFieldsValid(): boolean;
 	}
 
 	let submitAddNodeProvider: submitAddNodeProviderComponent;
@@ -20,7 +20,7 @@
 			return;
 		}
 
-		if (!submitAddNodeProvider.checkFields()) {
+		if (!submitAddNodeProvider.allFieldsValid()) {
 			return;
 		}
 

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -420,7 +420,6 @@ export const fieldsValid = (
 	}
 
 	if (!isSHA256(hashSelfDeclaration, hashIdentityProof)) {
-		toasts.error({ msg: { text: 'Invalid hash: make sure this is a SHA256 hash' } });
 		return false;
 	}
 
@@ -459,5 +458,19 @@ const urlsFromWiki = (urlSelfDeclaration: string, urlIdentityProof: string): boo
 
 const isSHA256 = (hashSelfDeclaration: string, hashIdentityProof: string): boolean => {
 	const sha256Regex = /^[a-fA-F0-9]{64}$/;
-	return sha256Regex.test(hashSelfDeclaration) && sha256Regex.test(hashIdentityProof);
+
+	try {
+		if (!sha256Regex.test(hashSelfDeclaration)) {
+			throw new Error(`Hash for Self Declaration document should be of type SHA256`);
+		}
+
+		if (!sha256Regex.test(hashIdentityProof)) {
+			throw new Error(`Hash for Proof of Identity document should be of type SHA256`);
+		}
+
+		return true;
+	} catch (err) {
+		toasts.error({ msg: { text: `Invalid URL` }, err });
+		return false;
+	}
 };

--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -24,6 +24,7 @@ import { replaceHistory } from '$lib/utils/route.utils';
 import { isNullish } from '@dfinity/utils';
 import { getDoc, setDoc, type Doc } from '@junobuild/core-peer';
 import { nanoid } from 'nanoid';
+import { fileURLToPath } from 'url';
 
 export const initUserProposal = async ({
 	user,
@@ -390,3 +391,67 @@ const assertTimestamps = async () => {
 		);
 	}
 };
+
+export const checkFields = (
+	nodeProviderName: string,
+	url: string,
+	urlSelfDeclaration: string,
+	hashSelfDeclaration: string,
+	urlIdentityProof: string,
+	hashIdentityProof: string,
+	nodeProviderId: string
+  ): boolean => {
+	const validUrlDomain = 'https://wiki.internetcomputer.org/';
+	const sha256Regex = /^[a-fA-F0-9]{64}$/;
+	const fields = [
+	  nodeProviderName,
+	  url,
+	  urlSelfDeclaration,
+	  hashSelfDeclaration,
+	  urlIdentityProof,
+	  hashIdentityProof,
+	  nodeProviderId
+	];
+  
+	if (fields.some((field) => field === '' || field === undefined)) {
+	  toasts.error({
+		msg: { text: 'Please fill in all fields' }
+	  });
+	  return false;
+	}
+  
+	if (!urlSelfDeclaration.startsWith(validUrlDomain)) {
+	  toasts.error({
+		msg: {
+		  text: 'Invalid URL for self-declaration: make sure the url is from <https://wiki.internetcomputer.org/>'
+		}
+	  });
+	  return false;
+	}
+  
+	if (!urlIdentityProof.startsWith(validUrlDomain)) {
+	  toasts.error({
+		msg: {
+		  text: 'Invalid URL for identity proof: make sure the url is from <https://wiki.internetcomputer.org/>'
+		}
+	  });
+	  return false;
+	}
+  
+	if (!sha256Regex.test(hashSelfDeclaration)) {
+	  toasts.error({
+		msg: { text: 'Invalid hash for self-declaration: make sure this is a SHA256 hash' }
+	  });
+	  return false;
+	}
+  
+	if (!sha256Regex.test(hashIdentityProof)) {
+	  toasts.error({
+		msg: { text: 'Invalid hash for proof of identity: make sure this is a SHA256 hash' }
+	  });
+	  return false;
+	}
+  
+	return true;
+  };
+  


### PR DESCRIPTION
### Description
Fixes #19 
Principal ID and forum url already has validation built in from NNS backend. This PR adds validation to make sure that:
- All fields are present
- URLs for self declaration and proof of identity comes from the IC wiki
- Hash for self declaration and proof of identity is a sha256 hash

### Changes Made
When `SubmitContinue` is clicked in `SubmitWrite.svelte`, a function from the `SubmitAddNodeProvider` will be called to validate the input fields.

### Testing
Tested through UI.


Thanks in advance for taking the time to review this PR!