### PR TITLE
feat: the ICP dashboard expect single quote for nore providers

### DIFF
--- a/src/lib/services/submit.services.ts
+++ b/src/lib/services/submit.services.ts
@@ -236,7 +236,7 @@ export const submitAddNodeProviderProposal = async ({
 		}
 
 		const title = `Add Node Provider: ${metadata?.nodeProviderName}`;
-		const summary = `Register a node provider "**${metadata?.nodeProviderName}**", in line with the announcement and discussion at [${metadata?.url}](${metadata?.url}).\n\nThe self-declaration documentation is available at [${metadata?.urlSelfDeclaration}](${metadata?.urlSelfDeclaration}) with SHA256 hash \`${metadata?.hashSelfDeclaration}\`.\n\nThe proof of identity is available at [${metadata?.urlIdentityProof}](${metadata?.urlIdentityProof}) with SHA256 hash \`${metadata?.hashIdentityProof}\`.`;
+		const summary = `Register a node provider '${metadata?.nodeProviderName}', in line with the announcement and discussion at [${metadata?.url}](${metadata?.url}).\n\nThe self-declaration documentation is available at [${metadata?.urlSelfDeclaration}](${metadata?.urlSelfDeclaration}) with SHA256 hash \`${metadata?.hashSelfDeclaration}\`.\n\nThe proof of identity is available at [${metadata?.urlIdentityProof}](${metadata?.urlIdentityProof}) with SHA256 hash \`${metadata?.hashIdentityProof}\`.`;
 
 		return submitAddNodeProviderProposalApi({
 			title,


### PR DESCRIPTION
The ICP Dashboard is not that clever and expects the node provider name to be enclosed in single quotes in Node Provider proposals to extract and display the name on the dashboard.