### PR TITLE
feat: init wizard with query params

### DIFF
--- a/src/lib/types/nav.ts
+++ b/src/lib/types/nav.ts
@@ -7,7 +7,7 @@ export type RouteParams = {
 };
 
 export type SubmitRouteParams = RouteParams & {
-	action: ProposalAction | null | undefined;
+	action: ProposalAction | string | null | undefined;
 	destination: string | null | undefined;
 	amount: string | null | undefined;
 };

--- a/src/lib/types/nav.ts
+++ b/src/lib/types/nav.ts
@@ -1,5 +1,13 @@
+import type { ProposalAction } from '$lib/types/governance';
+
 export type RouteParams = {
 	key: string | null | undefined;
 	id: string | null | undefined;
 	g: string | null | undefined;
+};
+
+export type SubmitRouteParams = RouteParams & {
+	action: ProposalAction | null | undefined;
+	destination: string | null | undefined;
+	amount: string | null | undefined;
 };

--- a/src/lib/utils/nav.utils.ts
+++ b/src/lib/utils/nav.utils.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
-import type { OptionGovernanceId } from '$lib/types/governance';
+import type { OptionGovernanceId, ProposalAction } from '$lib/types/governance';
 import type { RouteParams, SubmitRouteParams } from '$lib/types/nav';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent } from '@sveltejs/kit';
@@ -88,7 +88,8 @@ export const loadSubmitRouteParams = ($event: LoadEvent): SubmitRouteParams => {
 		return {
 			...params,
 			destination: undefined,
-			amount: undefined
+			amount: undefined,
+			action: undefined
 		};
 	}
 
@@ -99,6 +100,7 @@ export const loadSubmitRouteParams = ($event: LoadEvent): SubmitRouteParams => {
 	return {
 		...params,
 		destination: searchParams?.get('destination'),
-		amount: searchParams?.get('amount')
+		amount: searchParams?.get('amount'),
+		action: searchParams?.get('action') as ProposalAction | string | undefined | null
 	};
 };

--- a/src/lib/utils/nav.utils.ts
+++ b/src/lib/utils/nav.utils.ts
@@ -1,7 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import type { OptionGovernanceId } from '$lib/types/governance';
-import type { RouteParams } from '$lib/types/nav';
+import type { RouteParams, SubmitRouteParams } from '$lib/types/nav';
 import { isNullish, nonNullish } from '@dfinity/utils';
 import type { LoadEvent } from '@sveltejs/kit';
 
@@ -78,5 +78,27 @@ export const loadRouteParams = ($event: LoadEvent): RouteParams => {
 		key: searchParams?.get('key'),
 		id: searchParams?.get('id'),
 		g: searchParams?.get('g')
+	};
+};
+
+export const loadSubmitRouteParams = ($event: LoadEvent): SubmitRouteParams => {
+	const params = loadRouteParams($event);
+
+	if (!browser) {
+		return {
+			...params,
+			destination: undefined,
+			amount: undefined
+		};
+	}
+
+	const {
+		url: { searchParams }
+	} = $event;
+
+	return {
+		...params,
+		destination: searchParams?.get('destination'),
+		amount: searchParams?.get('amount')
 	};
 };

--- a/src/routes/(split)/submit/+page.ts
+++ b/src/routes/(split)/submit/+page.ts
@@ -1,6 +1,7 @@
-import type { RouteParams } from '$lib/types/nav';
-import { loadRouteParams } from '$lib/utils/nav.utils';
+import type { SubmitRouteParams } from '$lib/types/nav';
+import { loadSubmitRouteParams } from '$lib/utils/nav.utils';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ($event: LoadEvent): RouteParams => loadRouteParams($event);
+export const load: PageLoad = ($event: LoadEvent): SubmitRouteParams =>
+	loadSubmitRouteParams($event);


### PR DESCRIPTION
Locally a proposal can be initialized with following parameters:

`http://localhost:5173/submit?g=bd3sg-teaaa-aaaaa-qaaba-cai&action=TransferSnsTreasuryFunds&destination=123&amount=12324243`

Adapted for mainnet:

`https://proposals.network/submit?g=<GOVERNANCE_CANISTER_ID_TEXT>&action=TransferSnsTreasuryFunds&destination=<ICRC_ACCOUNT_TEXT>&amount=<ICP_E8S_AMOUNT>`