### PR TITLE
feat: sns init yaml max 10 events

### DIFF
--- a/src/lib/types/sns.ts
+++ b/src/lib/types/sns.ts
@@ -308,7 +308,7 @@ const swapSchema = z.object({
 	confirmation_text: confirmationSchema.optional(),
 	restricted_countries: countryCodeSchema.array().optional(),
 	VestingSchedule: z.object({
-		events: z.number().min(2),
+		events: z.number().min(2).max(10),
 		interval: durationSchema
 	}),
 	start_time: DEV ? timeOfDaySchema.optional() : timeOfDaySchema,


### PR DESCRIPTION
According this commit in the IC repo it's now max 10 events

https://github.com/dfinity/ic/commit/653d0e6d6650da379472db5a439ba3cb12ce1215