### PR TITLE
chore: typo in comment

### DIFF
--- a/src/lib/components/ui/Json.svelte
+++ b/src/lib/components/ui/Json.svelte
@@ -192,7 +192,7 @@
 			left: 0;
 			top: 0;
 			/* Move left to compensate for the padding of the ul */
-			/* Move down to componsate for the gap between li */
+			/* Move down to compensate for the gap between li */
 			transform: translate(-1rem, calc(0.8 * 0.25rem));
 		}
 		&.expanded::before {


### PR DESCRIPTION
# Motivation

Fix a typo in a comment.

# Credits

Credits go to @damuzhi0810 for spotting and correct similar typo in [Juno](https://github.com/junobuild/juno/pull/1144).
